### PR TITLE
Full UDP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ Append `-auth` to the encryption method to enable [One Time Auth (OTA)](https://
 - For server: this will **force client use OTA**, non-OTA connection will be dropped. Otherwise, both OTA and non-OTA clients can connect
 - For client: the `-A` command line option can also enable OTA
 
+### UDP relay
+
+Use `-u` command line options when starting server to enable UDP relay.
+
+Currently only tested with Shadowsocks-Android, if you have encountered any problem, please report.
+
 ## Command line options
 
 Command line options can override settings from configuration files. Use `-h` option to see all available options.

--- a/cmd/shadowsocks-server/server.go
+++ b/cmd/shadowsocks-server/server.go
@@ -37,6 +37,7 @@ const (
 )
 
 var debug ss.DebugLog
+var udp bool
 
 func getRequest(conn *ss.Conn, auth bool) (host string, ota bool, err error) {
 	ss.SetReadTimeout(conn)
@@ -175,14 +176,26 @@ type PortListener struct {
 	listener net.Listener
 }
 
+type UDPListener struct {
+	password string
+	listener *net.UDPConn
+}
+
 type PasswdManager struct {
 	sync.Mutex
 	portListener map[string]*PortListener
+	udpListener  map[string]*UDPListener
 }
 
 func (pm *PasswdManager) add(port, password string, listener net.Listener) {
 	pm.Lock()
 	pm.portListener[port] = &PortListener{password, listener}
+	pm.Unlock()
+}
+
+func (pm *PasswdManager) addUDP(port, password string, listener *net.UDPConn) {
+	pm.Lock()
+	pm.udpListener[port] = &UDPListener{password, listener}
 	pm.Unlock()
 }
 
@@ -193,14 +206,31 @@ func (pm *PasswdManager) get(port string) (pl *PortListener, ok bool) {
 	return
 }
 
+func (pm *PasswdManager) getUDP(port string) (pl *UDPListener, ok bool) {
+	pm.Lock()
+	pl, ok = pm.udpListener[port]
+	pm.Unlock()
+	return
+}
+
 func (pm *PasswdManager) del(port string) {
 	pl, ok := pm.get(port)
 	if !ok {
 		return
 	}
+	if udp {
+		upl, ok := pm.getUDP(port)
+		if !ok {
+			return
+		}
+		upl.listener.Close()
+	}
 	pl.listener.Close()
 	pm.Lock()
 	delete(pm.portListener, port)
+	if udp {
+		delete(pm.udpListener, port)
+	}
 	pm.Unlock()
 }
 
@@ -222,9 +252,14 @@ func (pm *PasswdManager) updatePortPasswd(port, password string, auth bool) {
 	// run will add the new port listener to passwdManager.
 	// So there maybe concurrent access to passwdManager and we need lock to protect it.
 	go run(port, password, auth)
+	if udp {
+		pl, _ := pm.getUDP(port)
+		pl.listener.Close()
+		go runUDP(port, password)
+	}
 }
 
-var passwdManager = PasswdManager{portListener: map[string]*PortListener{}}
+var passwdManager = PasswdManager{portListener: map[string]*PortListener{}, udpListener: map[string]*UDPListener{}}
 
 func updatePasswd() {
 	log.Println("updating password")
@@ -297,6 +332,31 @@ func run(port, password string, auth bool) {
 	}
 }
 
+func runUDP(port, password string) {
+	var cipher *ss.Cipher
+	port_i, _ := strconv.Atoi(port)
+	log.Printf("listening udp port %v\n", port)
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{
+		IP:   net.IPv6zero,
+		Port: port_i,
+	})
+	passwdManager.addUDP(port, password, conn)
+	if err != nil {
+		log.Printf("error listening udp port %v: %v\n", port, err)
+		return
+	}
+	defer conn.Close()
+	cipher, err = ss.NewCipher(config.Method, password)
+	if err != nil {
+		log.Printf("Error generating cipher for udp port: %s %v\n", port, err)
+		conn.Close()
+	}
+	UDPConn := ss.NewUDPConn(conn, cipher.Copy())
+	for {
+		UDPConn.ReadAndHandleUDPReq()
+	}
+}
+
 func enoughOptions(config *ss.Config) bool {
 	return config.ServerPort != 0 && config.Password != ""
 }
@@ -335,7 +395,7 @@ func main() {
 	flag.StringVar(&cmdConfig.Method, "m", "", "encryption method, default: aes-256-cfb")
 	flag.IntVar(&core, "core", 0, "maximum number of CPU cores to use, default is determinied by Go runtime")
 	flag.BoolVar((*bool)(&debug), "d", false, "print debug message")
-
+	flag.BoolVar(&udp, "u", false, "UDP Relay")
 	flag.Parse()
 
 	if printVer {
@@ -376,6 +436,9 @@ func main() {
 	}
 	for port, password := range config.PortPassword {
 		go run(port, password, config.Auth)
+		if udp {
+			go runUDP(port, password)
+		}
 	}
 
 	waitSignal()

--- a/shadowsocks/config.go
+++ b/shadowsocks/config.go
@@ -38,6 +38,7 @@ type Config struct {
 }
 
 var readTimeout time.Duration
+var udpTimeout time.Duration
 
 func (config *Config) GetServerArray() []string {
 	// Specifying multiple servers in the "server" options is deprecated.
@@ -91,6 +92,7 @@ func ParseConfig(path string) (config *Config, err error) {
 		config.Method = config.Method[:len(config.Method)-5]
 		config.Auth = true
 	}
+	udpTimeout = time.Duration(config.Timeout) * time.Second
 	return
 }
 
@@ -133,4 +135,5 @@ func UpdateConfig(old, new *Config) {
 
 	old.Timeout = new.Timeout
 	readTimeout = time.Duration(old.Timeout) * time.Second
+	udpTimeout = time.Duration(old.Timeout) * time.Second
 }

--- a/shadowsocks/config.go
+++ b/shadowsocks/config.go
@@ -38,7 +38,6 @@ type Config struct {
 }
 
 var readTimeout time.Duration
-var udpTimeout time.Duration
 
 func (config *Config) GetServerArray() []string {
 	// Specifying multiple servers in the "server" options is deprecated.
@@ -92,7 +91,6 @@ func ParseConfig(path string) (config *Config, err error) {
 		config.Method = config.Method[:len(config.Method)-5]
 		config.Auth = true
 	}
-	udpTimeout = time.Duration(config.Timeout) * time.Second
 	return
 }
 
@@ -135,5 +133,4 @@ func UpdateConfig(old, new *Config) {
 
 	old.Timeout = new.Timeout
 	readTimeout = time.Duration(old.Timeout) * time.Second
-	udpTimeout = time.Duration(old.Timeout) * time.Second
 }

--- a/shadowsocks/udp.go
+++ b/shadowsocks/udp.go
@@ -293,6 +293,9 @@ func (c *UDPConn) ReadFromUDP(b []byte) (n int, src *net.UDPAddr, err error) {
 	if err = c.initDecrypt(iv); err != nil {
 		return
 	}
+	if n < c.info.ivLen {
+		return 0, nil, fmt.Errorf("[udp]write error: cannot decrypt")
+	}
 	c.decrypt(b[0:n - c.info.ivLen], buf[c.info.ivLen : n])
 	n = n - c.info.ivLen
 	return

--- a/shadowsocks/udp.go
+++ b/shadowsocks/udp.go
@@ -1,0 +1,333 @@
+package shadowsocks
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"time"
+	"syscall"
+	"sync"
+)
+
+const (
+	idType  = 0 // address type index
+	idIP0   = 1 // ip addres start index
+	idDmLen = 1 // domain address length index
+	idDm0   = 2 // domain address start index
+
+	typeIPv4 = 1 // type is ipv4 address
+	typeDm   = 3 // type is domain address
+	typeIPv6 = 4 // type is ipv6 address
+
+	lenIPv4   = 1 + net.IPv4len + 2 // 1addrType + ipv4 + 2port
+	lenIPv6   = 1 + net.IPv6len + 2 // 1addrType + ipv6 + 2port
+	lenDmBase = 1 + 1 + 2           // 1addrType + 1addrLen + 2port, plus addrLen
+)
+
+type UDP interface {
+	ReadFromUDP(b []byte) (n int, src *net.UDPAddr, err error)
+	Read(b []byte) (n int, err error)
+	WriteToUDP(b []byte, src *net.UDPAddr) (n int, err error)
+	Write(b []byte) (n int, err error)
+	Close() error
+	SetWriteDeadline(t time.Time) error
+	SetReadDeadline(t time.Time) error
+	LocalAddr() net.Addr
+	RemoteAddr() net.Addr
+	ReadFrom(b []byte) (int, net.Addr, error)
+}
+
+type UDPConn struct {
+	UDP
+	*Cipher
+}
+
+func NewUDPConn(cn UDP, cipher *Cipher) *UDPConn {
+	return &UDPConn{cn, cipher}
+}
+
+type CachedUDPConn struct {
+	timer *time.Timer
+	UDP
+	i string
+}
+
+func NewCachedUDPConn(cn UDP) *CachedUDPConn {
+	return &CachedUDPConn{nil, cn, ""}
+}
+
+func (c *CachedUDPConn) Check() {
+	go nl.Delete(c.i)
+}
+
+func (c *CachedUDPConn) Close() error{
+	c.timer.Stop()
+	return c.UDP.Close()
+}
+
+func (c *CachedUDPConn) SetTimer(index string) {
+	c.i = index
+	c.timer = time.AfterFunc(120*time.Second, c.Check)
+}
+
+func (c *CachedUDPConn) Refresh() bool {
+	return c.timer.Reset(120*time.Second)
+}
+
+type NATlist struct {
+	sync.Mutex
+	Conns map[string]*CachedUDPConn
+	AliveConns int
+}
+
+func (nl *NATlist) Delete(srcaddr string) {
+	nl.Lock()
+	c , ok := nl.Conns[srcaddr]
+	if ok {
+		c.Close()
+		delete(nl.Conns, srcaddr)
+		nl.AliveConns -= 1
+	}
+	for k, _  := range ReqList {
+		delete(ReqList, k)
+	}
+	defer nl.Unlock()
+}
+
+func (nl *NATlist) Get(srcaddr *net.UDPAddr, ss *UDPConn) (c *CachedUDPConn, ok bool, err error){
+	nl.Lock()
+	defer nl.Unlock()
+	index := srcaddr.String()
+	_ , ok = nl.Conns[index]
+	if !ok {
+		//NAT not exists or expired
+		nl.AliveConns += 1
+		delete(nl.Conns, index)
+		ok = false
+		//full cone
+		conn, err := net.ListenUDP("udp", &net.UDPAddr{
+			IP:   net.IPv6zero,
+			Port: 0,
+		})
+		if err != nil {
+			return nil, false, err
+		}
+		nl.Conns[index] = NewCachedUDPConn(conn)
+		c , _ = nl.Conns[index]
+		c.SetTimer(index)
+		go Pipeloop(ss, srcaddr, c)
+	} else {
+		//NAT exists
+		c , _ = nl.Conns[index]
+		c.Refresh()
+	}
+	err = nil
+	return
+}
+
+func ParseHeader(addr net.Addr) ([]byte, int) {
+//what if the request address type is domain???
+	ip, port, err := net.SplitHostPort(addr.String())
+	if err != nil {
+		return nil, 0
+	}
+	buf := make([]byte, 20)
+	IP := net.ParseIP(ip)
+	b1 := IP.To4()
+	iplen := 0
+	if b1 == nil { //ipv6
+		b1 = IP.To16()
+		buf[0] = typeIPv6
+		iplen = net.IPv6len
+	} else { //ipv4
+		buf[0] = typeIPv4
+		iplen = net.IPv4len
+	}
+	copy(buf[1:], b1)
+	port_i, _ := strconv.Atoi(port)
+	binary.BigEndian.PutUint16(buf[1+iplen:], uint16(port_i))
+	return buf[:1+iplen+2], 1+iplen+2
+}
+
+func Pipeloop(ss *UDPConn, srcaddr *net.UDPAddr, remote UDP) {
+	buf := udpBuf.Get()
+	defer udpBuf.Put(buf)
+	defer nl.Delete(srcaddr.String())
+	for{
+		remote.SetReadDeadline(time.Now().Add(readTimeout))
+		n, raddr, err := remote.ReadFrom(buf)
+		if err != nil {
+			if ne, ok := err.(*net.OpError); ok && (ne.Err == syscall.EMFILE || ne.Err == syscall.ENFILE) {
+				// log too many open file error
+				// EMFILE is process reaches open file limits, ENFILE is system limit
+				fmt.Println("[udp]read error:", err)
+			} else if ne.Err.Error() == "use of closed network connection" {
+				fmt.Println("[udp]Connection Closing:", remote.LocalAddr())
+			} else {
+				fmt.Println("[udp]error reading from:", remote.LocalAddr(), err)
+			}
+			return
+		}
+		// need improvement here
+		if N, ok := ReqList[raddr.String()]; ok {
+			go ss.WriteToUDP(append(N.Req[:N.ReqLen], buf[:n]...), srcaddr)
+		}	else {
+			header, hlen := ParseHeader(raddr)
+			go ss.WriteToUDP(append(header[:hlen], buf[:n]...), srcaddr)
+		}
+	}
+}
+
+type ReqNode struct {
+	Req []byte
+	ReqLen int
+}
+
+var ReqList = map[string]*ReqNode{}
+
+var nl = NATlist{Conns: map[string]*CachedUDPConn{}}
+
+var udpBuf = NewLeakyBuf(nBuf, bufSize)
+
+func (c *UDPConn) handleUDPConnection(n int, src *net.UDPAddr, receive []byte) {
+	var dstIP net.IP
+	var reqLen int
+	defer udpBuf.Put(receive)
+
+	switch receive[idType] {
+	case typeIPv4:
+		reqLen = lenIPv4
+		dstIP = net.IP(receive[idIP0 : idIP0+net.IPv4len])
+	case typeIPv6:
+		reqLen = lenIPv6
+		dstIP = net.IP(receive[idIP0 : idIP0+net.IPv6len])
+	case typeDm:
+		reqLen = int(receive[idDmLen]) + lenDmBase
+		dIP, err := net.ResolveIPAddr("ip" ,string(receive[idDm0 : idDm0+receive[idDmLen]]))
+		if err != nil{
+			fmt.Sprintf("[udp]failed to resolve domain name: %s\n", string(receive[idDm0 : idDm0+receive[idDmLen]]))
+			return
+		}
+		dstIP = dIP.IP
+	default:
+		fmt.Sprintf("[udp]addr type %d not supported", receive[idType])
+		return
+	}
+	dst := &net.UDPAddr{
+		IP:   dstIP,
+		Port: int(binary.BigEndian.Uint16(receive[reqLen-2 : reqLen])),
+	}
+	if _, ok := ReqList[dst.String()]; !ok {
+		req := make([]byte, reqLen)
+		for i:=0;i<reqLen;i++ {
+			req[i] = receive[i]
+		}
+		ReqList[dst.String()] = &ReqNode{req, reqLen}
+	}
+
+	remote, _, err := nl.Get(src, c)
+	if err != nil {
+		return
+	}
+	remote.SetWriteDeadline(time.Now().Add(readTimeout))
+	_, err = remote.WriteToUDP(receive[reqLen:n], dst)
+	if err != nil {
+		if ne, ok := err.(*net.OpError); ok && (ne.Err == syscall.EMFILE || ne.Err == syscall.ENFILE) {
+			// log too many open file error
+			// EMFILE is process reaches open file limits, ENFILE is system limit
+			fmt.Println("[udp]write error:", err)
+		} else {
+			fmt.Println("[udp]error connecting to:", dst, err)
+		}
+		return
+	}
+	// Pipeloop
+	return
+}
+
+func (c *UDPConn) ReadAndHandleUDPReq()  {
+	buf := udpBuf.Get()
+	n, src, err := c.ReadFromUDP(buf[0:])
+	if err != nil {
+		return
+	}
+	go c.handleUDPConnection(n, src, buf)
+}
+
+//n is the size of the payload
+func (c *UDPConn) ReadFromUDP(b []byte) (n int, src *net.UDPAddr, err error) {
+	buf := udpBuf.Get()
+	n, src, err = c.UDP.ReadFromUDP(buf[0:])
+	if err != nil {
+		return
+	}
+	defer udpBuf.Put(buf)
+
+	iv := buf[:c.info.ivLen]
+	if err = c.initDecrypt(iv); err != nil {
+		return
+	}
+	c.decrypt(b[0:n - c.info.ivLen], buf[c.info.ivLen : n])
+	n = n - c.info.ivLen
+	return
+}
+
+func (c *UDPConn) Read(b []byte) (n int, err error) {
+	buf := udpBuf.Get()
+	n, err = c.UDP.Read(buf[0:])
+	if err != nil {
+		return
+	}
+	defer udpBuf.Put(buf)
+
+	iv := buf[:c.info.ivLen]
+	if err = c.initDecrypt(iv); err != nil {
+		return
+	}
+	c.decrypt(b[0:n - c.info.ivLen], buf[c.info.ivLen : n])
+	n = n - c.info.ivLen
+	return
+}
+
+//n = iv + payload
+func (c *UDPConn) WriteToUDP(b []byte, src *net.UDPAddr) (n int, err error) {
+	var cipherData []byte
+	dataStart := 0
+
+	var iv []byte
+	iv, err = c.initEncrypt()
+	if err != nil {
+		return
+	}
+	// Put initialization vector in buffer, do a single write to send both
+	// iv and data.
+	cipherData = make([]byte, len(b)+len(iv))
+	copy(cipherData, iv)
+	dataStart = len(iv)
+	
+	c.encrypt(cipherData[dataStart:], b)
+	n, err = c.UDP.WriteToUDP(cipherData, src)
+	return
+}
+
+func (c *UDPConn) Write(b []byte) (n int, err error) {
+	var cipherData []byte
+	dataStart := 0
+
+	var iv []byte
+	iv, err = c.initEncrypt()
+	if err != nil {
+		return
+	}
+	// Put initialization vector in buffer, do a single write to send both
+	// iv and data.
+	cipherData = make([]byte, len(b)+len(iv))
+	copy(cipherData, iv)
+	dataStart = len(iv)
+	
+	c.encrypt(cipherData[dataStart:], b)
+	n, err = c.UDP.Write(cipherData)
+	return
+}

--- a/shadowsocks/udp.go
+++ b/shadowsocks/udp.go
@@ -1,345 +1,91 @@
 package shadowsocks
 
 import (
-	"encoding/binary"
-	"fmt"
+	"errors"
 	"net"
-	"strconv"
-	"time"
-	"syscall"
-	"sync"
 )
-
-const (
-	idType    = 0 // address type index
-	idIP0     = 1 // ip addres start index
-	idDmLen   = 1 // domain address length index
-	idDm0     = 2 // domain address start index
-
-	typeIPv4  = 1 // type is ipv4 address
-	typeDm    = 3 // type is domain address
-	typeIPv6  = 4 // type is ipv6 address
-
-	lenIPv4   = 1 + net.IPv4len + 2 // 1addrType + ipv4 + 2port
-	lenIPv6   = 1 + net.IPv6len + 2 // 1addrType + ipv6 + 2port
-	lenDmBase = 1 + 1 + 2           // 1addrType + 1addrLen + 2port, plus addrLen
-)
-
-var (
-	reqList   = ReqList{List:map[string]*ReqNode{}}
-	nl        = NATlist{Conns: map[string]*CachedUDPConn{}}
-)
-
-type UDP interface {
-	ReadFromUDP(b []byte) (n int, src *net.UDPAddr, err error)
-	Read(b []byte) (n int, err error)
-	WriteToUDP(b []byte, src *net.UDPAddr) (n int, err error)
-	Write(b []byte) (n int, err error)
-	Close() error
-	SetWriteDeadline(t time.Time) error
-	SetReadDeadline(t time.Time) error
-	LocalAddr() net.Addr
-	RemoteAddr() net.Addr
-	ReadFrom(b []byte) (int, net.Addr, error)
-}
 
 type UDPConn struct {
-	UDP
+	*net.UDPConn
 	*Cipher
+	readBuf []byte
+	// writeBuf []byte
+	// for shadowsocks-go
+	natlist NATlist
 }
 
-func NewUDPConn(cn UDP, cipher *Cipher) *UDPConn {
-	return &UDPConn{cn, cipher}
-}
-
-type CachedUDPConn struct {
-	timer *time.Timer
-	UDP
-	i string // scraddr
-}
-
-func NewCachedUDPConn(cn UDP) *CachedUDPConn {
-	return &CachedUDPConn{nil, cn, ""}
-}
-
-func (c *CachedUDPConn) Check() {
-	go nl.Delete(c.i)
-}
-
-func (c *CachedUDPConn) Close() error{
-	c.timer.Stop()
-	return c.UDP.Close()
-}
-
-func (c *CachedUDPConn) SetTimer(index string) {
-	c.i = index
-	c.timer = time.AfterFunc(120*time.Second, c.Check)
-}
-
-func (c *CachedUDPConn) Refresh() bool {
-	return c.timer.Reset(120*time.Second)
-}
-
-type NATlist struct {
-	sync.Mutex
-	Conns map[string]*CachedUDPConn
-	AliveConns int
-}
-
-func (nl *NATlist) Delete(srcaddr string) {
-	nl.Lock()
-	c , ok := nl.Conns[srcaddr]
-	if ok {
-		c.Close()
-		delete(nl.Conns, srcaddr)
-		nl.AliveConns -= 1
-	}
-	reqList.Refresh()
-	defer nl.Unlock()
-}
-
-func (nl *NATlist) Get(srcaddr *net.UDPAddr, ss *UDPConn) (c *CachedUDPConn, ok bool, err error){
-	nl.Lock()
-	defer nl.Unlock()
-	index := srcaddr.String()
-	_ , ok = nl.Conns[index]
-	if !ok {
-		//NAT not exists or expired
-		nl.AliveConns += 1
-		delete(nl.Conns, index)
-		ok = false
-		//full cone
-		conn, err := net.ListenUDP("udp", &net.UDPAddr{
-			IP:   net.IPv6zero,
-			Port: 0,
-		})
-		if err != nil {
-			return nil, false, err
-		}
-		nl.Conns[index] = NewCachedUDPConn(conn)
-		c , _ = nl.Conns[index]
-		c.SetTimer(index)
-		go Pipeloop(ss, srcaddr, c)
-	} else {
-		//NAT exists
-		c , _ = nl.Conns[index]
-		c.Refresh()
-	}
-	err = nil
-	return
-}
-
-type ReqNode struct {
-	Req []byte
-	ReqLen int
-}
-
-type ReqList struct {
-	List map[string]*ReqNode
-	sync.Mutex
-}
-
-func (r *ReqList) Refresh() {
-	r.Lock()
-	defer r.Unlock()
-	for k, _  := range r.List {
-		delete(r.List, k)
+func NewUDPConn(c *net.UDPConn, cipher *Cipher) *UDPConn {
+	return &UDPConn{
+		UDPConn: c,
+		Cipher:  cipher,
+		readBuf: leakyBuf.Get(),
+		// for thread safety
+		// writeBuf: leakyBuf.Get(),
+		// for shadowsocks-go
+		natlist: NATlist{conns: map[string]*CachedUDPConn{}},
 	}
 }
 
-func (r *ReqList) Get(dstaddr string) (req *ReqNode, ok bool) {
-	r.Lock()
-	defer r.Unlock()
-	req, ok = r.List[dstaddr]
-	return
-}
-
-func (r *ReqList) Put(dstaddr string, req *ReqNode) {
-	r.Lock()
-	defer r.Unlock()
-	r.List[dstaddr] = req
-	return
-}
-
-func ParseHeader(addr net.Addr) ([]byte, int) {
-//what if the request address type is domain???
-	ip, port, err := net.SplitHostPort(addr.String())
-	if err != nil {
-		return nil, 0
-	}
-	buf := make([]byte, 20)
-	IP := net.ParseIP(ip)
-	b1 := IP.To4()
-	iplen := 0
-	if b1 == nil { //ipv6
-		b1 = IP.To16()
-		buf[0] = typeIPv6
-		iplen = net.IPv6len
-	} else { //ipv4
-		buf[0] = typeIPv4
-		iplen = net.IPv4len
-	}
-	copy(buf[1:], b1)
-	port_i, _ := strconv.Atoi(port)
-	binary.BigEndian.PutUint16(buf[1+iplen:], uint16(port_i))
-	return buf[:1+iplen+2], 1+iplen+2
-}
-
-func Pipeloop(ss *UDPConn, srcaddr *net.UDPAddr, remote UDP) {
-	buf := leakyBuf.Get()
-	defer leakyBuf.Put(buf)
-	defer nl.Delete(srcaddr.String())
-	for{
-		remote.SetReadDeadline(time.Now().Add(readTimeout))
-		n, raddr, err := remote.ReadFrom(buf)
-		if err != nil {
-			if ne, ok := err.(*net.OpError); ok && (ne.Err == syscall.EMFILE || ne.Err == syscall.ENFILE) {
-				// log too many open file error
-				// EMFILE is process reaches open file limits, ENFILE is system limit
-				fmt.Println("[udp]read error:", err)
-			} else if ne.Err.Error() == "use of closed network connection" {
-				fmt.Println("[udp]Connection Closing:", remote.LocalAddr())
-			} else {
-				fmt.Println("[udp]error reading from:", remote.LocalAddr(), err)
-			}
-			return
-		}
-		// need improvement here
-		if N, ok := reqList.Get(raddr.String()); ok {
-			go ss.WriteToUDP(append(N.Req[:N.ReqLen], buf[:n]...), srcaddr)
-		}	else {
-			header, hlen := ParseHeader(raddr)
-			go ss.WriteToUDP(append(header[:hlen], buf[:n]...), srcaddr)
-		}
-	}
-}
-
-func (c *UDPConn) handleUDPConnection(n int, src *net.UDPAddr, receive []byte) {
-	var dstIP net.IP
-	var reqLen int
-	defer leakyBuf.Put(receive)
-
-	switch receive[idType] {
-	case typeIPv4:
-		reqLen = lenIPv4
-		dstIP = net.IP(receive[idIP0 : idIP0+net.IPv4len])
-	case typeIPv6:
-		reqLen = lenIPv6
-		dstIP = net.IP(receive[idIP0 : idIP0+net.IPv6len])
-	case typeDm:
-		reqLen = int(receive[idDmLen]) + lenDmBase
-		dIP, err := net.ResolveIPAddr("ip" ,string(receive[idDm0 : idDm0+receive[idDmLen]]))
-		if err != nil{
-			fmt.Sprintf("[udp]failed to resolve domain name: %s\n", string(receive[idDm0 : idDm0+receive[idDmLen]]))
-			return
-		}
-		dstIP = dIP.IP
-	default:
-		fmt.Sprintf("[udp]addr type %d not supported", receive[idType])
-		return
-	}
-	dst := &net.UDPAddr{
-		IP:   dstIP,
-		Port: int(binary.BigEndian.Uint16(receive[reqLen-2 : reqLen])),
-	}
-	if _, ok := reqList.Get(dst.String()); !ok {
-		req := make([]byte, reqLen)
-		for i:=0;i<reqLen;i++ {
-			req[i] = receive[i]
-		}
-		reqList.Put(dst.String(), &ReqNode{req, reqLen})
-	}
-
-	remote, _, err := nl.Get(src, c)
-	if err != nil {
-		return
-	}
-	remote.SetWriteDeadline(time.Now().Add(readTimeout))
-	_, err = remote.WriteToUDP(receive[reqLen:n], dst)
-	if err != nil {
-		if ne, ok := err.(*net.OpError); ok && (ne.Err == syscall.EMFILE || ne.Err == syscall.ENFILE) {
-			// log too many open file error
-			// EMFILE is process reaches open file limits, ENFILE is system limit
-			fmt.Println("[udp]write error:", err)
-		} else {
-			fmt.Println("[udp]error connecting to:", dst, err)
-		}
-		return
-	}
-	// Pipeloop
-	return
-}
-
-func (c *UDPConn) ReadAndHandleUDPReq()  {
-	buf := leakyBuf.Get()
-	n, src, err := c.ReadFromUDP(buf[0:])
-	if err != nil {
-		return
-	}
-	go c.handleUDPConnection(n, src, buf)
-}
-
-//n is the size of the payload
-func (c *UDPConn) ReadFromUDP(b []byte) (n int, src *net.UDPAddr, err error) {
-	buf := leakyBuf.Get()
-	n, src, err = c.UDP.ReadFromUDP(buf[0:])
-	if err != nil {
-		return
-	}
-	defer leakyBuf.Put(buf)
-
-	iv := buf[:c.info.ivLen]
-	if err = c.initDecrypt(iv); err != nil {
-		return
-	}
-	if n < c.info.ivLen {
-		return 0, nil, fmt.Errorf("[udp]write error: cannot decrypt")
-	}
-	c.decrypt(b[0:n - c.info.ivLen], buf[c.info.ivLen : n])
-	n = n - c.info.ivLen
-	return
+func (c *UDPConn) Close() error {
+	leakyBuf.Put(c.readBuf)
+	//leakyBuf.Put(c.writeBuf)
+	return c.UDPConn.Close()
 }
 
 func (c *UDPConn) Read(b []byte) (n int, err error) {
-	buf := leakyBuf.Get()
-	n, err = c.UDP.Read(buf[0:])
+	buf := c.readBuf
+	n, err = c.UDPConn.Read(buf[0:])
 	if err != nil {
 		return
 	}
-	defer leakyBuf.Put(buf)
 
 	iv := buf[:c.info.ivLen]
 	if err = c.initDecrypt(iv); err != nil {
 		return
 	}
-	c.decrypt(b[0:n - c.info.ivLen], buf[c.info.ivLen : n])
+	c.decrypt(b[0:n-c.info.ivLen], buf[c.info.ivLen:n])
 	n = n - c.info.ivLen
 	return
 }
 
-//n = iv + payload
-func (c *UDPConn) WriteToUDP(b []byte, src *net.UDPAddr) (n int, err error) {
-	var cipherData []byte
-	dataStart := 0
-
-	var iv []byte
-	iv, err = c.initEncrypt()
+func (c *UDPConn) ReadFrom(b []byte) (n int, src net.Addr, err error) {
+	n, src, err = c.UDPConn.ReadFrom(c.readBuf[0:])
 	if err != nil {
 		return
 	}
-	// Put initialization vector in buffer, do a single write to send both
-	// iv and data.
-	cipherData = make([]byte, len(b)+len(iv))
-	copy(cipherData, iv)
-	dataStart = len(iv)
-	
-	c.encrypt(cipherData[dataStart:], b)
-	n, err = c.UDP.WriteToUDP(cipherData, src)
+	if n < c.info.ivLen {
+		return 0, nil, errors.New("[udp]read error: cannot decrypt")
+	}
+	iv := make([]byte, c.info.ivLen)
+	copy(iv, c.readBuf[:c.info.ivLen])
+	if err = c.initDecrypt(iv); err != nil {
+		return
+	}
+	c.decrypt(b[0:n-c.info.ivLen], c.readBuf[c.info.ivLen:n])
+	n = n - c.info.ivLen
 	return
 }
 
+func (c *UDPConn) ReadFromUDP(b []byte) (n int, src *net.UDPAddr, err error) {
+	n, src, err = c.UDPConn.ReadFromUDP(c.readBuf[0:])
+	if err != nil {
+		return
+	}
+	if n < c.info.ivLen {
+		return 0, nil, errors.New("[udp]read error: cannot decrypt")
+	}
+	iv := make([]byte, c.info.ivLen)
+	copy(iv, c.readBuf[:c.info.ivLen])
+	if err = c.initDecrypt(iv); err != nil {
+		return
+	}
+	c.decrypt(b[0:n-c.info.ivLen], c.readBuf[c.info.ivLen:n])
+	n = n - c.info.ivLen
+	return
+}
+
+// Maybe some thread safe issue with Write and encryption
 func (c *UDPConn) Write(b []byte) (n int, err error) {
-	var cipherData []byte
 	dataStart := 0
 
 	var iv []byte
@@ -349,11 +95,45 @@ func (c *UDPConn) Write(b []byte) (n int, err error) {
 	}
 	// Put initialization vector in buffer, do a single write to send both
 	// iv and data.
-	cipherData = make([]byte, len(b)+len(iv))
+	cipherData := make([]byte, len(b)+len(iv))
 	copy(cipherData, iv)
 	dataStart = len(iv)
-	
+
 	c.encrypt(cipherData[dataStart:], b)
-	n, err = c.UDP.Write(cipherData)
+	n, err = c.UDPConn.Write(cipherData)
+	return
+}
+
+func (c *UDPConn) WriteTo(b []byte, dst net.Addr) (n int, err error) {
+	var iv []byte
+	iv, err = c.initEncrypt()
+	if err != nil {
+		return
+	}
+	// Put initialization vector in buffer, do a single write to send both
+	// iv and data.
+	cipherData := make([]byte, len(b)+len(iv))
+	copy(cipherData, iv)
+	dataStart := len(iv)
+
+	c.encrypt(cipherData[dataStart:], b)
+	n, err = c.UDPConn.WriteTo(cipherData, dst)
+	return
+}
+
+func (c *UDPConn) WriteToUDP(b []byte, dst *net.UDPAddr) (n int, err error) {
+	var iv []byte
+	iv, err = c.initEncrypt()
+	if err != nil {
+		return
+	}
+	// Put initialization vector in buffer, do a single write to send both
+	// iv and data.
+	cipherData := make([]byte, len(b)+len(iv))
+	copy(cipherData, iv)
+	dataStart := len(iv)
+
+	c.encrypt(cipherData[dataStart:], b)
+	n, err = c.UDPConn.WriteToUDP(cipherData, dst)
 	return
 }

--- a/shadowsocks/udprelay.go
+++ b/shadowsocks/udprelay.go
@@ -1,0 +1,240 @@
+package shadowsocks
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+	"strconv"
+	"sync"
+	"syscall"
+	"time"
+)
+
+const (
+	idType  = 0 // address type index
+	idIP0   = 1 // ip addres start index
+	idDmLen = 1 // domain address length index
+	idDm0   = 2 // domain address start index
+
+	typeIPv4 = 1 // type is ipv4 address
+	typeDm   = 3 // type is domain address
+	typeIPv6 = 4 // type is ipv6 address
+
+	lenIPv4   = 1 + net.IPv4len + 2 // 1addrType + ipv4 + 2port
+	lenIPv6   = 1 + net.IPv6len + 2 // 1addrType + ipv6 + 2port
+	lenDmBase = 1 + 1 + 2           // 1addrType + 1addrLen + 2port, plus addrLen
+)
+
+var (
+	reqList = ReqList{List: map[string]*ReqNode{}}
+)
+
+type CachedUDPConn struct {
+	*net.UDPConn
+	srcaddr_index string
+}
+
+func NewCachedUDPConn(udpconn *net.UDPConn, index string) *CachedUDPConn {
+	return &CachedUDPConn{udpconn, index}
+}
+
+func (c *CachedUDPConn) Close() error {
+	return c.UDPConn.Close()
+}
+
+type NATlist struct {
+	sync.Mutex
+	conns map[string]*CachedUDPConn
+}
+
+func (self *NATlist) Delete(index string) {
+	self.Lock()
+	c, ok := self.conns[index]
+	if ok {
+		c.Close()
+		delete(self.conns, index)
+	}
+	// Socks5 Request header processing
+	reqList.Refresh()
+	defer self.Unlock()
+}
+
+func (self *NATlist) Get(index string) (c *CachedUDPConn, ok bool, err error) {
+	self.Lock()
+	defer self.Unlock()
+	c, ok = self.conns[index]
+	if !ok {
+		//NAT not exists or expired
+		//delete(self.conns, index)
+		//ok = false
+		//full cone
+		conn, err := net.ListenUDP("udp", &net.UDPAddr{
+			IP:   net.IPv6zero,
+			Port: 0,
+		})
+		if err != nil {
+			return nil, ok, err
+		}
+		c = NewCachedUDPConn(conn, index)
+		self.conns[index] = c
+	}
+	err = nil
+	return
+}
+
+type ReqNode struct {
+	Req    []byte
+	ReqLen int
+}
+
+type ReqList struct {
+	List map[string]*ReqNode
+	sync.Mutex
+}
+
+func (r *ReqList) Refresh() {
+	r.Lock()
+	defer r.Unlock()
+	for k, _ := range r.List {
+		delete(r.List, k)
+	}
+}
+
+func (r *ReqList) Get(dstaddr string) (req *ReqNode, ok bool) {
+	r.Lock()
+	defer r.Unlock()
+	req, ok = r.List[dstaddr]
+	return
+}
+
+func (r *ReqList) Put(dstaddr string, req *ReqNode) {
+	r.Lock()
+	defer r.Unlock()
+	r.List[dstaddr] = req
+	return
+}
+
+func ParseHeader(addr net.Addr) ([]byte, int) {
+	//what if the request address type is domain???
+	ip, port, err := net.SplitHostPort(addr.String())
+	if err != nil {
+		return nil, 0
+	}
+	buf := make([]byte, 20)
+	IP := net.ParseIP(ip)
+	b1 := IP.To4()
+	iplen := 0
+	if b1 == nil { //ipv6
+		b1 = IP.To16()
+		buf[0] = typeIPv6
+		iplen = net.IPv6len
+	} else { //ipv4
+		buf[0] = typeIPv4
+		iplen = net.IPv4len
+	}
+	copy(buf[1:], b1)
+	port_i, _ := strconv.Atoi(port)
+	binary.BigEndian.PutUint16(buf[1+iplen:], uint16(port_i))
+	return buf[:1+iplen+2], 1 + iplen + 2
+}
+
+func Pipeloop(ss *UDPConn, srcaddr *net.UDPAddr, remote *CachedUDPConn) {
+	buf := leakyBuf.Get()
+	defer leakyBuf.Put(buf)
+	for {
+		remote.SetDeadline(time.Now().Add(readTimeout))
+		n, raddr, err := remote.ReadFrom(buf)
+		if err != nil {
+			if ne, ok := err.(*net.OpError); ok && (ne.Err == syscall.EMFILE || ne.Err == syscall.ENFILE) {
+				// log too many open file error
+				// EMFILE is process reaches open file limits, ENFILE is system limit
+				fmt.Println("[udp]read error:", err)
+			} else if ne.Err.Error() == "use of closed network connection" {
+				fmt.Println("[udp]Connection Closing:", remote.LocalAddr())
+			} else {
+				fmt.Println("[udp]error reading from:", remote.LocalAddr(), err)
+			}
+			return
+		}
+		// need improvement here
+		if N, ok := reqList.Get(raddr.String()); ok {
+			go ss.WriteToUDP(append(N.Req[:N.ReqLen], buf[:n]...), srcaddr)
+		} else {
+			header, hlen := ParseHeader(raddr)
+			go ss.WriteToUDP(append(header[:hlen], buf[:n]...), srcaddr)
+		}
+	}
+}
+
+func (c *UDPConn) handleUDPConnection(n int, src *net.UDPAddr, receive []byte) {
+	var dstIP net.IP
+	var reqLen int
+	defer leakyBuf.Put(receive)
+
+	switch receive[idType] {
+	case typeIPv4:
+		reqLen = lenIPv4
+		dstIP = net.IP(receive[idIP0 : idIP0+net.IPv4len])
+	case typeIPv6:
+		reqLen = lenIPv6
+		dstIP = net.IP(receive[idIP0 : idIP0+net.IPv6len])
+	case typeDm:
+		reqLen = int(receive[idDmLen]) + lenDmBase
+		dIP, err := net.ResolveIPAddr("ip", string(receive[idDm0:idDm0+receive[idDmLen]]))
+		if err != nil {
+			fmt.Sprintf("[udp]failed to resolve domain name: %s\n", string(receive[idDm0:idDm0+receive[idDmLen]]))
+			return
+		}
+		dstIP = dIP.IP
+	default:
+		fmt.Sprintf("[udp]addr type %d not supported", receive[idType])
+		return
+	}
+	dst := &net.UDPAddr{
+		IP:   dstIP,
+		Port: int(binary.BigEndian.Uint16(receive[reqLen-2 : reqLen])),
+	}
+	if _, ok := reqList.Get(dst.String()); !ok {
+		req := make([]byte, reqLen)
+		for i := 0; i < reqLen; i++ {
+			req[i] = receive[i]
+		}
+		reqList.Put(dst.String(), &ReqNode{req, reqLen})
+	}
+
+	remote, exist, err := c.natlist.Get(src.String())
+	if err != nil {
+		return
+	}
+	if !exist {
+		go func() {
+			Pipeloop(c, src, remote)
+			c.natlist.Delete(src.String())
+		}()
+	}
+	remote.SetDeadline(time.Now().Add(udpTimeout))
+	go func() {
+		_, err = remote.WriteToUDP(receive[reqLen:n], dst)
+		if err != nil {
+			if ne, ok := err.(*net.OpError); ok && (ne.Err == syscall.EMFILE || ne.Err == syscall.ENFILE) {
+				// log too many open file error
+				// EMFILE is process reaches open file limits, ENFILE is system limit
+				fmt.Println("[udp]write error:", err)
+			} else {
+				fmt.Println("[udp]error connecting to:", dst, err)
+			}
+			c.natlist.Delete(src.String())
+		}
+	}()
+	// Pipeloop
+	return
+}
+
+func (c *UDPConn) ReadAndHandleUDPReq() {
+	buf := leakyBuf.Get()
+	n, src, err := c.ReadFromUDP(buf[0:])
+	if err != nil {
+		return
+	}
+	go c.handleUDPConnection(n, src, buf)
+}


### PR DESCRIPTION
加了一个NATlist，以及一个Pipeloop。
现在Handler只负责把收到的请求往远端写。
Pipeloop负责读远端的回复，并转到客户端。
用python做本地客户端，实测openvpn udp模式可看y2b视频，8M宽带满速。
建议超时设置在2分钟左右。
稳定性上还体验不到与python服务器的差别，需要更长时间的测试。
