### PR TITLE
Exit server if port is not bindable

### DIFF
--- a/cmd/shadowsocks-server/server.go
+++ b/cmd/shadowsocks-server/server.go
@@ -261,7 +261,7 @@ func run(port, password string) {
 	ln, err := net.Listen("tcp", ":"+port)
 	if err != nil {
 		log.Printf("error listening port %v: %v\n", port, err)
-		return
+		os.Exit(1)
 	}
 	passwdManager.add(port, password, ln)
 	var cipher *ss.Cipher


### PR DESCRIPTION
For comparison I also looked at the python version which also exits if it cannot bind the port.

There are probably more cases where an Exit is more appropriate than a return. However this is the one that causes me problems right now.