### PR TITLE
Add golang.org/x/net/proxy Dialer interface.

### DIFF
--- a/shadowsocks/proxy.go
+++ b/shadowsocks/proxy.go
@@ -38,7 +38,7 @@ func NewDialer(server string, cipher *Cipher) (dialer *Dialer, err error) {
 	}, nil
 }
 
-func (d *Dialer) Dial(network, addr string) (c *ProxyConn, err error) {
+func (d *Dialer) Dial(network, addr string) (c net.Conn, err error) {
 	if strings.HasPrefix(network, "tcp") {
 		conn, err := Dial(addr, d.server, d.cipher)
 		if err != nil {

--- a/shadowsocks/proxy.go
+++ b/shadowsocks/proxy.go
@@ -40,7 +40,7 @@ func NewDialer(server string, cipher *Cipher) (dialer *Dialer, err error) {
 
 func (d *Dialer) Dial(network, addr string) (c net.Conn, err error) {
 	if strings.HasPrefix(network, "tcp") {
-		conn, err := Dial(addr, d.server, d.cipher)
+		conn, err := Dial(addr, d.server, d.cipher.Copy())
 		if err != nil {
 			return nil, err
 		}

--- a/shadowsocks/proxy.go
+++ b/shadowsocks/proxy.go
@@ -1,0 +1,34 @@
+package shadowsocks
+
+import (
+	"errors"
+	"strings"
+	"fmt"
+)
+
+type Dialer struct {
+	cipher *Cipher
+	server string
+	support_udp bool
+}
+
+var ErrNilCipher = errors.New("cipher can't be nil.")
+
+func NewDialer(server string, cipher *Cipher) (dialer *Dialer, err error) {
+	// Currently shadowsocks-go do not support UDP
+	if cipher == nil {
+		return nil, ErrNilCipher
+	}
+	return &Dialer {
+		cipher: cipher,
+		server: server,
+		support_udp: false,
+	}, nil
+}
+
+func (d *Dialer) Dial(network, addr string) (c *Conn, err error) {
+	if strings.HasPrefix(network, "tcp") {
+		return Dial(addr, d.server, d.cipher)
+	}
+	return nil, fmt.Errorf("unsupported connection type: %s", network)
+}

--- a/shadowsocks/proxy.go
+++ b/shadowsocks/proxy.go
@@ -4,12 +4,24 @@ import (
 	"errors"
 	"strings"
 	"fmt"
+	"net"
+	"time"
 )
 
 type Dialer struct {
 	cipher *Cipher
 	server string
 	support_udp bool
+}
+
+type ProxyConn struct {
+	*Conn
+	raddr *ProxyAddr
+}
+
+type ProxyAddr struct {
+	network string
+	address string
 }
 
 var ErrNilCipher = errors.New("cipher can't be nil.")
@@ -26,9 +38,47 @@ func NewDialer(server string, cipher *Cipher) (dialer *Dialer, err error) {
 	}, nil
 }
 
-func (d *Dialer) Dial(network, addr string) (c *Conn, err error) {
+func (d *Dialer) Dial(network, addr string) (c *ProxyConn, err error) {
 	if strings.HasPrefix(network, "tcp") {
-		return Dial(addr, d.server, d.cipher)
+		conn, err := Dial(addr, d.server, d.cipher)
+		if err != nil {
+			return nil, err
+		}
+		return &ProxyConn {
+			Conn: conn,
+			raddr: &ProxyAddr {
+				network: network,
+				address: addr,
+			},
+		}, nil
 	}
 	return nil, fmt.Errorf("unsupported connection type: %s", network)
+}
+
+func (c *ProxyConn) LocalAddr() net.Addr {
+	return c.Conn.LocalAddr()
+}
+
+func (c *ProxyConn) RemoteAddr() net.Addr {
+	return c.raddr
+}
+
+func (c *ProxyConn) SetDeadline(t time.Time) error {
+	return c.Conn.SetDeadline(t)
+}
+
+func (c *ProxyConn) SetReadDeadline(t time.Time) error {
+	return c.Conn.SetReadDeadline(t)
+}
+
+func (c *ProxyConn) SetWriteDeadline(t time.Time) error {
+	return c.Conn.SetWriteDeadline(t)
+}
+
+func (a *ProxyAddr) Network() string {
+	return a.network
+}
+
+func (a *ProxyAddr) String() string {
+	return a.address
 }


### PR DESCRIPTION
Other golang projects can now integrate with shadowsocks-go much easier.