### PR TITLE
Cipher cache should include encryption method in key

### DIFF
--- a/cmd/shadowsocks-local/local.go
+++ b/cmd/shadowsocks-local/local.go
@@ -208,14 +208,17 @@ func parseServerConfig(config *ss.Config) {
 			if !hasPort(server) {
 				log.Fatalf("no port for server %s\n", server)
 			}
-			cipher, ok := cipherCache[passwd]
+			// Using "|" as delimiter is safe here, since no encryption
+			// method contains it in the name.
+			cacheKey := encmethod + "|" + passwd
+			cipher, ok := cipherCache[cacheKey]
 			if !ok {
 				var err error
 				cipher, err = ss.NewCipher(encmethod, passwd)
 				if err != nil {
 					log.Fatal("Failed generating ciphers:", err)
 				}
-				cipherCache[passwd] = cipher
+				cipherCache[cacheKey] = cipher
 			}
 			servers.srvCipher[i] = &ServerCipher{server, cipher}
 			i++


### PR DESCRIPTION
... otherwise two servers with different encryption method but same
password will share the same cipher, and client will fail to authenticate.

Instead of using map[string]map[string]*ss.Cipher, just prepend password
with encryption method name and a delimiter "|" as cache key. Since there
are no encryption methods with "|" in their names (and unlikely any further
ones), it's safe to use this delimiter.

Another problem is that, no method provided ("") is equivalent to "table",
but will have two entries in cipher cache. But it's hard to know the default
encryption method from package ss, and "table" is rarely used, this won't
be a big problem.