### PR TITLE
shadowsocks-server 支持通过 all_proxy 环境变量来设置socks 代理

### DIFF
--- a/cmd/shadowsocks-server/server.go
+++ b/cmd/shadowsocks-server/server.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log"
 	"net"
+	"golang.org/x/net/proxy"
 	"os"
 	"os/signal"
 	"runtime"
@@ -124,7 +125,9 @@ func handleConnection(conn *ss.Conn) {
 		return
 	}
 	debug.Println("connecting", host)
-	remote, err := net.Dial("tcp", host)
+	var dialer proxy.Dialer
+	dialer = proxy.FromEnvironment()
+	remote, err := dialer.Dial("tcp", host)
 	if err != nil {
 		if ne, ok := err.(*net.OpError); ok && (ne.Err == syscall.EMFILE || ne.Err == syscall.ENFILE) {
 			// log too many open file error


### PR DESCRIPTION
如果在国内建立ss服务器来转发国外ss时，可以通过在国内服务器上的shadowsocks-server使用shadowsocks-local所建立的socks5 proxy，来完成中转。
这个pull request就是通过设置shadowsocks-server启动时的all_proxy环境变量，来实现请求。
如：all_proxy=socks5://127.0.0.1:1080 shadowsocks-server ...
