### PR TITLE
added "shadowsocks-go-docker" to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ go get github.com/shadowsocks/shadowsocks-go/cmd/shadowsocks-local
 
 It's recommended to disable cgo when compiling shadowsocks-go. This will prevent the go runtime from creating too many threads for dns lookup.
 
+If you are using Docker, please check on [shadowsocks-go-docker](https://github.com/Kaijun/shadowsocks-go-docker).
+
 # Usage
 
 Both the server and client program will look for `config.json` in the current directory. You can use `-c` option to specify another configuration file.


### PR DESCRIPTION
Hi, I just created a Dockerfile ([shadowsocks-go-docker](https://github.com/Kaijun/shadowsocks-go-docker)) for building image based on shadowsocks-go. 

I'm not pretty sure if you all need it.

sure feel free to close 😄 
