### PR TITLE
Using net.DialTimeout to connect servers

### DIFF
--- a/shadowsocks/conn.go
+++ b/shadowsocks/conn.go
@@ -59,7 +59,7 @@ func RawAddr(addr string) (buf []byte, err error) {
 // rawaddr shoud contain part of the data in socks request, starting from the
 // ATYP field. (Refer to rfc1928 for more information.)
 func DialWithRawAddr(rawaddr []byte, server string, cipher *Cipher) (c *Conn, err error) {
-	conn, err := net.Dial("tcp", server)
+	conn, err := net.DialTimeout("tcp", server, readTimeout)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
When server is dead, the connection will hung forever.
This patch fix it.
