### PR TITLE
Minor improvement : listen to address according to config 

### DIFF
--- a/cmd/shadowsocks-server/server.go
+++ b/cmd/shadowsocks-server/server.go
@@ -17,7 +17,7 @@ import (
 	"sync"
 	"syscall"
 
-	ss "github.com/lijinpei/shadowsocks-go/shadowsocks"
+	ss "github.com/shadowsocks/shadowsocks-go/shadowsocks"
 )
 
 const (

--- a/cmd/shadowsocks-server/server.go
+++ b/cmd/shadowsocks-server/server.go
@@ -17,7 +17,7 @@ import (
 	"sync"
 	"syscall"
 
-	ss "github.com/shadowsocks/shadowsocks-go/shadowsocks"
+	ss "github.com/lijinpei/shadowsocks-go/shadowsocks"
 )
 
 const (
@@ -208,7 +208,7 @@ func (pm *PasswdManager) del(port string) {
 // port. A different approach would be directly change the password used by
 // that port, but that requires **sharing** password between the port listener
 // and password manager.
-func (pm *PasswdManager) updatePortPasswd(port, password string, auth bool) {
+func (pm *PasswdManager) updatePortPasswd(address, port, password string, auth bool) {
 	pl, ok := pm.get(port)
 	if !ok {
 		log.Printf("new port %s added\n", port)
@@ -216,12 +216,12 @@ func (pm *PasswdManager) updatePortPasswd(port, password string, auth bool) {
 		if pl.password == password {
 			return
 		}
-		log.Printf("closing port %s to update password\n", port)
+		log.Printf("closing address %v port %s to update password\n", address, port)
 		pl.listener.Close()
 	}
 	// run will add the new port listener to passwdManager.
 	// So there maybe concurrent access to passwdManager and we need lock to protect it.
-	go run(port, password, auth)
+	go run(address, port, password, auth)
 }
 
 var passwdManager = PasswdManager{portListener: map[string]*PortListener{}}
@@ -240,7 +240,7 @@ func updatePasswd() {
 		return
 	}
 	for port, passwd := range config.PortPassword {
-		passwdManager.updatePortPasswd(port, passwd, config.Auth)
+		passwdManager.updatePortPasswd(config.Server, port, passwd, config.Auth)
 		if oldconfig.PortPassword != nil {
 			delete(oldconfig.PortPassword, port)
 		}
@@ -267,15 +267,15 @@ func waitSignal() {
 	}
 }
 
-func run(port, password string, auth bool) {
-	ln, err := net.Listen("tcp", ":"+port)
+func run(address, port, password string, auth bool) {
+	ln, err := net.Listen("tcp", address+":"+port)
 	if err != nil {
-		log.Printf("error listening port %v: %v\n", port, err)
+		log.Printf("error listening address %v port %v: %v\n", address, port, err)
 		os.Exit(1)
 	}
 	passwdManager.add(port, password, ln)
 	var cipher *ss.Cipher
-	log.Printf("server listening port %v ...\n", port)
+	log.Printf("server listening address %v port %v ...\n", address, port)
 	for {
 		conn, err := ln.Accept()
 		if err != nil {
@@ -285,7 +285,7 @@ func run(port, password string, auth bool) {
 		}
 		// Creating cipher upon first connection.
 		if cipher == nil {
-			log.Println("creating cipher for port:", port)
+			log.Println("creating cipher for port :", port)
 			cipher, err = ss.NewCipher(config.Method, password)
 			if err != nil {
 				log.Printf("Error generating cipher for port: %s %v\n", port, err)
@@ -375,7 +375,7 @@ func main() {
 		runtime.GOMAXPROCS(core)
 	}
 	for port, password := range config.PortPassword {
-		go run(port, password, config.Auth)
+		go run(config.Server, port, password, config.Auth)
 	}
 
 	waitSignal()

--- a/shadowsocks/config.go
+++ b/shadowsocks/config.go
@@ -19,7 +19,7 @@ import (
 )
 
 type Config struct {
-	Server     interface{} `json:"server"`
+	Server     string      `json:"server"`
 	ServerPort int         `json:"server_port"`
 	LocalPort  int         `json:"local_port"`
 	Password   string      `json:"password"`
@@ -38,7 +38,7 @@ type Config struct {
 }
 
 var readTimeout time.Duration
-
+/*
 func (config *Config) GetServerArray() []string {
 	// Specifying multiple servers in the "server" options is deprecated.
 	// But for backward compatiblity, keep this.
@@ -51,12 +51,10 @@ func (config *Config) GetServerArray() []string {
 	}
 	arr, ok := config.Server.([]interface{})
 	if ok {
-		/*
 			if len(arr) > 1 {
 				log.Println("Multiple servers in \"server\" option is deprecated. " +
 					"Please use \"server_password\" instead.")
 			}
-		*/
 		serverArr := make([]string, len(arr), len(arr))
 		for i, s := range arr {
 			serverArr[i], ok = s.(string)
@@ -69,7 +67,7 @@ func (config *Config) GetServerArray() []string {
 typeError:
 	panic(fmt.Sprintf("Config.Server type error %v", reflect.TypeOf(config.Server)))
 }
-
+*/
 func ParseConfig(path string) (config *Config, err error) {
 	file, err := os.Open(path) // For read access.
 	if err != nil {


### PR DESCRIPTION
changed from net.Listen("tcp", ":"+port) to net.Listen("tcp", address+":"+port) to listen to address according to config. However, due to implementation decision made by golang's net package https://github.com/golang/go/issues/5632  , listening to 0.0.0.0 hebaves differently than ususal. 