### PR TITLE
fix same iv on every connection

### DIFF
--- a/shadowsocks/encrypt.go
+++ b/shadowsocks/encrypt.go
@@ -250,6 +250,7 @@ func (c *Cipher) Copy() *Cipher {
 	// the nature of the algorithm.)
 
 	nc := *c
+	nc.iv = nil
 	nc.enc = nil
 	nc.dec = nil
 	nc.ota = c.ota


### PR DESCRIPTION
Hello, I found that every connection cipher iv is same, because of the copy of origin cipher.
It's a **serious** bug.
Solution is that set iv as nil for every copy.