### PR TITLE
Avoid same iv when copy cipher

### DIFF
--- a/shadowsocks/encrypt.go
+++ b/shadowsocks/encrypt.go
@@ -250,6 +250,7 @@ func (c *Cipher) Copy() *Cipher {
 	// the nature of the algorithm.)
 
 	nc := *c
+	nc.iv = nil
 	nc.enc = nil
 	nc.dec = nil
 	nc.ota = c.ota


### PR DESCRIPTION
Invalid use of `(c *Cipher) Copy() *Cipher`, may lead to two cipher have two same non-nil iv. 
To avoid this, set iv as nil.
It won't happen, but just in case.
