### PR TITLE
Supporting chacha20-ietf.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: go
 go:
-  - 1.4.3
+  - 1.7.4
 install:
   - go get golang.org/x/crypto/blowfish
   - go get golang.org/x/crypto/cast5
   - go get golang.org/x/crypto/salsa20
-  - go get github.com/codahale/chacha20
+  - go get github.com/Yawning/chacha20
   - go install ./cmd/shadowsocks-local
   - go install ./cmd/shadowsocks-server
 script:

--- a/shadowsocks/encrypt.go
+++ b/shadowsocks/encrypt.go
@@ -12,7 +12,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/codahale/chacha20"
+	"github.com/Yawning/chacha20"
 	"golang.org/x/crypto/blowfish"
 	"golang.org/x/crypto/cast5"
 	"golang.org/x/crypto/salsa20/salsa"
@@ -103,7 +103,11 @@ func newRC4MD5Stream(key, iv []byte, _ DecOrEnc) (cipher.Stream, error) {
 }
 
 func newChaCha20Stream(key, iv []byte, _ DecOrEnc) (cipher.Stream, error) {
-	return chacha20.New(key, iv)
+	return chacha20.NewCipher(key, iv)
+}
+
+func newChaCha20IETFStream(key, iv []byte, _ DecOrEnc) (cipher.Stream, error) {
+	return chacha20.NewCipher(key, iv)
 }
 
 type salsaStreamCipher struct {
@@ -153,18 +157,19 @@ type cipherInfo struct {
 }
 
 var cipherMethod = map[string]*cipherInfo{
-	"aes-128-cfb": {16, 16, newAESCFBStream},
-	"aes-192-cfb": {24, 16, newAESCFBStream},
-	"aes-256-cfb": {32, 16, newAESCFBStream},
-	"aes-128-ctr": {16, 16, newAESCTRStream},
-	"aes-192-ctr": {24, 16, newAESCTRStream},
-	"aes-256-ctr": {32, 16, newAESCTRStream},
-	"des-cfb":     {8, 8, newDESStream},
-	"bf-cfb":      {16, 8, newBlowFishStream},
-	"cast5-cfb":   {16, 8, newCast5Stream},
-	"rc4-md5":     {16, 16, newRC4MD5Stream},
-	"chacha20":    {32, 8, newChaCha20Stream},
-	"salsa20":     {32, 8, newSalsa20Stream},
+	"aes-128-cfb":   {16, 16, newAESCFBStream},
+	"aes-192-cfb":   {24, 16, newAESCFBStream},
+	"aes-256-cfb":   {32, 16, newAESCFBStream},
+	"aes-128-ctr":   {16, 16, newAESCTRStream},
+	"aes-192-ctr":   {24, 16, newAESCTRStream},
+	"aes-256-ctr":   {32, 16, newAESCTRStream},
+	"des-cfb":       {8, 8, newDESStream},
+	"bf-cfb":        {16, 8, newBlowFishStream},
+	"cast5-cfb":     {16, 8, newCast5Stream},
+	"rc4-md5":       {16, 16, newRC4MD5Stream},
+	"chacha20":      {32, 8, newChaCha20Stream},
+	"chacha20-ietf": {32, 12, newChaCha20IETFStream},
+	"salsa20":       {32, 8, newSalsa20Stream},
 }
 
 func CheckCipherMethod(method string) error {

--- a/shadowsocks/encrypt_test.go
+++ b/shadowsocks/encrypt_test.go
@@ -99,6 +99,10 @@ func TestChaCha20(t *testing.T) {
 	testBlockCipher(t, "chacha20")
 }
 
+func TestChaCha20IETF(t *testing.T) {
+	testBlockCipher(t, "chacha20-ietf")
+}
+
 var cipherKey = make([]byte, 64)
 var cipherIv = make([]byte, 64)
 
@@ -164,6 +168,10 @@ func BenchmarkChaCha20Init(b *testing.B) {
 	benchmarkCipherInit(b, "chacha20")
 }
 
+func BenchmarkChaCha20IETFInit(b *testing.B) {
+	benchmarkCipherInit(b, "chacha20-ietf")
+}
+
 func BenchmarkSalsa20Init(b *testing.B) {
 	benchmarkCipherInit(b, "salsa20")
 }
@@ -226,6 +234,10 @@ func BenchmarkRC4MD5Encrypt(b *testing.B) {
 
 func BenchmarkChacha20Encrypt(b *testing.B) {
 	benchmarkCipherEncrypt(b, "chacha20")
+}
+
+func BenchmarkChacha20IETFEncrypt(b *testing.B) {
+	benchmarkCipherEncrypt(b, "chacha20-ietf")
 }
 
 func BenchmarkSalsa20Encrypt(b *testing.B) {
@@ -295,6 +307,10 @@ func BenchmarkRC4MD5Decrypt(b *testing.B) {
 
 func BenchmarkChaCha20Decrypt(b *testing.B) {
 	benchmarkCipherDecrypt(b, "chacha20")
+}
+
+func BenchmarkChaCha20IETFDecrypt(b *testing.B) {
+	benchmarkCipherDecrypt(b, "chacha20-ietf")
 }
 
 func BenchmarkSalsa20Decrypt(b *testing.B) {


### PR DESCRIPTION
Supporting chacha20-ietf.
And using a new package to provide `chacha20` cipher, with higher performance.

old:
```
$ go test -test.bench=Chacha20Encrypt -test.benchtime=10s
BenchmarkChacha20Encrypt-28      1000000             16875 ns/op
PASS
ok      github.com/lixin9311/shadowsocks-go/shadowsocks 17.079s
```

new:
```
$ go test -test.bench=Chacha20Encrypt -test.benchtime=10s
BenchmarkChacha20Encrypt-28      5000000              2689 ns/op
PASS
ok      github.com/lixin9311/shadowsocks-go/shadowsocks 16.201s
```

about `chacha20-ietf`
#144 :
```
$ go test -test.bench=Chacha20IETFEncrypt -test.benchtime=10s
BenchmarkChacha20IETFEncrypt-28          5000000              2413 ns/op
PASS
ok      github.com/lixin9311/shadowsocks-go/shadowsocks 14.545s
```

new:
```
$ go test -test.bench=Chacha20IETFEncrypt -test.benchtime=10s
BenchmarkChacha20IETFEncrypt-28          5000000              2688 ns/op
PASS
ok      github.com/lixin9311/shadowsocks-go/shadowsocks 16.201s
```

not too much different,
to keep consistency, I personally prefer using this package.