### PR TITLE
修复对于多个服务器端都没有加密方式时会没有默认的加密方式的问题

### DIFF
--- a/cmd/shadowsocks-local/local.go
+++ b/cmd/shadowsocks-local/local.go
@@ -207,7 +207,7 @@ func parseServerConfig(config *ss.Config) {
 			}
 			server := serverInfo[0]
 			passwd := serverInfo[1]
-			encmethod := ""
+			encmethod := config.Method
 			if len(serverInfo) == 3 {
 				encmethod = serverInfo[2]
 			}

--- a/cmd/shadowsocks-local/local.go
+++ b/cmd/shadowsocks-local/local.go
@@ -367,7 +367,7 @@ func main() {
 	flag.IntVar(&cmdConfig.ServerPort, "p", 0, "server port")
 	flag.IntVar(&cmdConfig.Timeout, "t", 300, "timeout in seconds")
 	flag.IntVar(&cmdConfig.LocalPort, "l", 0, "local socks5 proxy port")
-	flag.StringVar(&cmdConfig.Method, "m", "", "encryption method, default: aes-256-cfb")
+	flag.StringVar(&cmdConfig.Method, "m", "aes-256-cfb", "encryption method, default: aes-256-cfb")
 	flag.BoolVar((*bool)(&debug), "d", false, "print debug message")
 	flag.BoolVar(&cmdConfig.Auth, "A", false, "one time auth")
 


### PR DESCRIPTION
{
	"local_port": 1080,
	"server_password": [
		["xx.xx.x.xx:xxx", "xxxxxxxxxxxx"],
		["xx.xx.x.xx:xxx", "xxxxxxxxxxxx"],
		["xx.xx.x.xx:xxx", "xxxxxxxxxxxx"]
	]
}

对于上面的配置文件，原程序会提示没有加密方式。是因为加密方式没有设置默认值的原因。