### PR TITLE
shodawsocks-local: add transparent proxy support

### DIFF
--- a/cmd/shadowsocks-local/redir.go
+++ b/cmd/shadowsocks-local/redir.go
@@ -1,0 +1,11 @@
+// +build !linux
+
+package main
+
+import (
+	"net"
+)
+
+func getOriginDst(c net.Conn) (net.Addr, error) {
+	return c.LocalAddr(), nil
+}

--- a/cmd/shadowsocks-local/redir_iptables.go
+++ b/cmd/shadowsocks-local/redir_iptables.go
@@ -1,0 +1,93 @@
+// +build linux,!cgo
+
+package main
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+	"syscall"
+	"unsafe"
+)
+
+const (
+	// SO_ORIGINAL_DST in linux/netfilter_ipv4.h
+	soOriginalDst = 80
+)
+
+func getOriginDst(c net.Conn) (net.Addr, error) {
+
+	cc, ok := c.(*net.TCPConn)
+	if !ok {
+		return nil, fmt.Errorf("only tcp socket supported")
+	}
+
+	f, err := cc.File()
+	if err != nil {
+		return nil, err
+	}
+
+	defer f.Close()
+
+	remoteIP := c.RemoteAddr().(*net.TCPAddr).IP
+	if remoteIP.To4() == nil {
+		// ipv6
+		// not supported, just return local socket address
+		return c.LocalAddr(), nil
+	}
+
+	// get original ip destination, in C like this
+	//
+	// struct sockaddr addr;
+	// memset(&addr, 0, sizeof(addr);
+	// int len = sizeof(addr);
+	// getsocketopt(fd, SOL_IP, SO_ORIGINAL_DST, &addr, &len);
+	//
+	//_, _, errno := syscall.Syscall6(sysGetSockOpt, f.Fd(),
+	//	uintptr(level), uintptr(soOriginalDst),
+	//	uintptr(unsafe.Pointer(&sockaddr)),
+	//	uintptr(unsafe.Pointer(&len)), 0)
+	maddr, err := syscall.GetsockoptIPv6Mreq(int(f.Fd()), syscall.SOL_IP, soOriginalDst)
+
+	if err != nil {
+		return nil, err
+	}
+
+	var port uint16
+	var ip net.IP
+	rawaddr := (*syscall.RawSockaddrInet4)(unsafe.Pointer(&maddr.Multiaddr))
+	ip = net.IP(rawaddr.Addr[0:])
+	port = ntohs(rawaddr.Port)
+
+	addr := &net.TCPAddr{IP: ip, Port: int(port)}
+	return addr, nil
+}
+
+func ntohs(a uint16) uint16 {
+	if isLittleEndian {
+		b := make([]byte, 2)
+		binary.BigEndian.PutUint16(b, a)
+		c := binary.LittleEndian.Uint16(b)
+		return c
+	}
+	return a
+}
+
+var isLittleEndian = isHostLittleEndian()
+
+func isHostLittleEndian() bool {
+	// determine the byte order
+
+	var num uint16 = 0x1234
+
+	buf := make([]byte, 2)
+
+	binary.BigEndian.PutUint16(buf, num)
+	p := (*[2]byte)(unsafe.Pointer(&num))
+	if p[0] != buf[0] {
+		// little endian
+		return true
+	}
+	// big endian
+	return false
+}

--- a/cmd/shadowsocks-local/redir_iptables_2.go
+++ b/cmd/shadowsocks-local/redir_iptables_2.go
@@ -1,0 +1,112 @@
+// +build linux,cgo
+
+package main
+
+/*
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <net/if.h>
+#include <netinet/in.h>
+#include <linux/netfilter_ipv4.h>
+#include <linux/netfilter_ipv6/ip6_tables.h>
+
+// the RPI toolchain does not have this macro
+#ifndef IP6T_SO_ORIGINAL_DST
+#define IP6T_SO_ORIGINAL_DST 80
+#endif
+
+int get_original_dst4(int fd, void *addr);
+int get_original_dst6(int fd, void *addr);
+
+unsigned short _ntohs(unsigned short a);
+
+int get_original_dst4(int fd, void *addr){
+	int ret;
+	int l = sizeof(struct sockaddr_in);
+	ret = getsockopt(fd, SOL_IP, SO_ORIGINAL_DST,
+		(struct sockaddr_in *)addr, &l);
+	return ret;
+}
+
+int get_original_dst6(int fd, void *addr){
+	int ret;
+	int l = sizeof(struct sockaddr_in6);
+	ret = getsockopt(fd, SOL_IPV6, IP6T_SO_ORIGINAL_DST,
+		(struct sockaddr_in6 *)addr, &l);
+	return ret;
+}
+
+unsigned short _ntohs(unsigned short a) {
+	return ntohs(a);
+}
+
+*/
+import "C"
+
+import (
+	"fmt"
+	//"log"
+	"net"
+	"syscall"
+	"unsafe"
+)
+
+func getOriginDst(c net.Conn) (net.Addr, error) {
+	var addr net.Addr
+	var err error
+
+	if _, ok := c.(*net.TCPConn); !ok {
+		return nil, fmt.Errorf("only tcp socket supported")
+	}
+
+	ip := c.LocalAddr().(*net.TCPAddr).IP
+
+	if ip.To4() != nil { // ipv4
+		addr, err = getOriginDst4(c)
+	} else {
+		addr, err = getOriginDst6(c)
+	}
+	return addr, err
+}
+
+func getOriginDst4(c net.Conn) (net.Addr, error) {
+
+	c1 := c.(*net.TCPConn)
+
+	f, _ := c1.File()
+
+	defer f.Close()
+
+	var addr4 syscall.RawSockaddrInet4
+
+	ret := C.get_original_dst4(C.int(f.Fd()), unsafe.Pointer(&addr4))
+	if int(ret) != 0 {
+		return nil, fmt.Errorf("ipv4 getsockopt SO_ORIGINAL_DST return %v", int(ret))
+	}
+
+	port := int(C._ntohs(C.ushort(addr4.Port)))
+	ip := net.IP(addr4.Addr[0:])
+
+	return &net.TCPAddr{IP: ip, Port: port}, nil
+}
+
+func getOriginDst6(c net.Conn) (net.Addr, error) {
+
+	c1 := c.(*net.TCPConn)
+
+	f, _ := c1.File()
+
+	defer f.Close()
+
+	var addr6 syscall.RawSockaddrInet6
+
+	ret := C.get_original_dst6(C.int(f.Fd()), unsafe.Pointer(&addr6))
+	if int(ret) != 0 {
+		return nil, fmt.Errorf("ipv6 getsockopt IP6T_ORIGINAL_DST return %v", int(ret))
+	}
+
+	port := int(C._ntohs(C.ushort(addr6.Port)))
+	ip := net.IP(addr6.Addr[0:])
+
+	return &net.TCPAddr{IP: ip, Port: port}, nil
+}


### PR DESCRIPTION
add transparent proxy support on linux with iptables

with this pr, 

we can redirect the traffic to shadowsocks-local's listen port with iptables,
 shadowsocks-local will get the original destination and contact it through
shadowsocks server.

so we can proxy some application that not support socks5 proxy.

when cgo enabled, use C.getsockopt to get original destination.
when cgo disabled, use syscall.getsockopt to get original destination.

Actually, this is samely as ss-redir on shadowsocks-libev.

to use transparent function, only need to configure iptables rule, refer to ss-redir's guide
https://github.com/shadowsocks/shadowsocks-libev#transparent-proxy
