### PR TITLE
Added a sample configuration for multiple IPv6 servers

### DIFF
--- a/sample-config/client-multi-server-ipv6.json
+++ b/sample-config/client-multi-server-ipv6.json
@@ -1,7 +1,0 @@
-{
-	"local_port": 1081,
-	"server_password": [
-		["[::1]:8387", "foobar"],
-		["[::1]:8388", "barfoo", "aes-128-cfb"]
-	]
-}

--- a/sample-config/client-multi-server-ipv6.json
+++ b/sample-config/client-multi-server-ipv6.json
@@ -1,0 +1,7 @@
+{
+	"local_port": 1081,
+	"server_password": [
+		["[::1]:8387", "foobar"],
+		["[::1]:8388", "barfoo", "aes-128-cfb"]
+	]
+}

--- a/sample-config/client-multi-server.json
+++ b/sample-config/client-multi-server.json
@@ -2,6 +2,7 @@
 	"local_port": 1081,
 	"server_password": [
 		["127.0.0.1:8387", "foobar"],
-		["127.0.0.1:8388", "barfoo", "aes-128-cfb"]
+		["127.0.0.1:8388", "barfoo", "aes-128-cfb"],
+		["[::1]:8389", "foobarfoo", "aes-128-cfb"]
 	]
 }


### PR DESCRIPTION
Add a new example to `sample-config/` so users can reference to configure multiple IPv6 servers.