### PR TITLE
respect timeout value in config file

### DIFF
--- a/cmd/shadowsocks-local/local.go
+++ b/cmd/shadowsocks-local/local.go
@@ -34,6 +34,8 @@ var (
 const (
 	socksVer5       = 5
 	socksCmdConnect = 1
+
+	defaultTimeout = 300
 )
 
 func init() {
@@ -414,7 +416,7 @@ func main() {
 	flag.StringVar(&cmdConfig.LocalAddress, "b", "", "local address, listen only to this address if specified")
 	flag.StringVar(&cmdConfig.Password, "k", "", "password")
 	flag.IntVar(&cmdConfig.ServerPort, "p", 0, "server port")
-	flag.IntVar(&cmdConfig.Timeout, "t", 300, "timeout in seconds")
+	flag.IntVar(&cmdConfig.Timeout, "t", 0, "timeout in seconds")
 	flag.IntVar(&cmdConfig.LocalPort, "l", 0, "local socks5 proxy port")
 	flag.StringVar(&cmdConfig.Method, "m", "", "encryption method, default: aes-256-cfb")
 	flag.BoolVar((*bool)(&debug), "d", false, "print debug message")
@@ -456,6 +458,9 @@ func main() {
 			os.Exit(1)
 		}
 	} else {
+		if config.Timeout == 0 && cmdConfig.Timeout == 0 {
+			cmdConfig.Timeout = defaultTimeout
+		}
 		ss.UpdateConfig(config, &cmdConfig)
 	}
 	if config.Method == "" {

--- a/cmd/shadowsocks-server/server.go
+++ b/cmd/shadowsocks-server/server.go
@@ -36,6 +36,8 @@ const (
 	lenIPv6   = net.IPv6len + 2 // ipv6 + 2port
 	lenDmBase = 2               // 1addrLen + 2port, plus addrLen
 	// lenHmacSha1 = 10
+
+	defaultTimeout = 300
 )
 
 var debug ss.DebugLog
@@ -437,7 +439,7 @@ func main() {
 	flag.StringVar(&configFile, "c", "config.json", "specify config file")
 	flag.StringVar(&cmdConfig.Password, "k", "", "password")
 	flag.IntVar(&cmdConfig.ServerPort, "p", 0, "server port")
-	flag.IntVar(&cmdConfig.Timeout, "t", 300, "timeout in seconds")
+	flag.IntVar(&cmdConfig.Timeout, "t", 0, "timeout in seconds")
 	flag.StringVar(&cmdConfig.Method, "m", "", "encryption method, default: aes-256-cfb")
 	flag.IntVar(&core, "core", 0, "maximum number of CPU cores to use, default is determinied by Go runtime")
 	flag.BoolVar((*bool)(&debug), "d", false, "print debug message")
@@ -463,6 +465,9 @@ func main() {
 		config = &cmdConfig
 		ss.UpdateConfig(config, config)
 	} else {
+		if config.Timeout == 0 && cmdConfig.Timeout == 0 {
+			cmdConfig.Timeout = defaultTimeout
+		}
 		ss.UpdateConfig(config, &cmdConfig)
 	}
 	if config.Method == "" {


### PR DESCRIPTION
Since `ss.UpdateConfig` will merge non-zero value in `new`, but `cmdConfig` from `flag.Parse` will always has a default value (300) from `flag.IntVar(&cmdConfig.Timeout, ....)`, so the `timeout` value from config file will always be overwritten until explicit specify `-t xxx` in cmd line.
This PR fix this issue and respect `timeout` value in config file if no `-t xxx` is specified in cmd line.